### PR TITLE
[Refactor] Make package pip installable, use installed script launcher

### DIFF
--- a/PyChop/__main__.py
+++ b/PyChop/__main__.py
@@ -23,7 +23,12 @@ else:
     app, within_mantid = get_qapplication()
  
 
-window = PyChopGui.PyChopGui()
-window.show()
-if not within_mantid:
-    sys.exit(app.exec_())
+def gui():
+    window = PyChopGui.PyChopGui()
+    window.show()
+    if not within_mantid:
+        sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    gui()

--- a/README.md
+++ b/README.md
@@ -9,3 +9,23 @@ and `multirep`, a Matlab program by R. I. Bewley.
 This is a port of the [Mantid PyChop](https://github.com/mantidproject/mantid/tree/master/scripts/PyChop) code to work without Mantid.
 
 Further documentation is available on the [Mantid webpage](https://docs.mantidproject.org/nightly/interfaces/PyChop.html)
+
+
+## Installation
+Optionally create and activate a `venv` virtual environment to isolate `PyChop` from your system packages
+```shell
+python -m venv pychop
+source pychop/bin/activate
+```
+
+Clone and install this repository with pip, e.g.:
+```shell
+python -m pip install git+https://github.com/mducle/pychop.git
+```
+this installation method should ensure that all requisite dependencies are available.
+
+## Usage
+Launch the `PyChop` GUI via the installed project script
+```shell
+PyChop
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "PyChop"
+dependencies = ['numpy', 'qtpy', 'matplotlib', 'PyYaml', 'scipy']
+dynamic = ["version"]
+
+#[project.optional-dependencies]
+# mantid = ['mantidqt', 'mantid']
+
+[project.scripts]
+PyChop = 'PyChop.__main__:gui'
+
+[tool.setuptools_scm]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["PyChop*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "PyChop"
-dependencies = ['numpy', 'qtpy', 'matplotlib', 'PyYaml', 'scipy']
+dependencies = ['numpy', 'qtpy', 'pyqt5', 'matplotlib', 'PyYaml', 'scipy']
 dynamic = ["version"]
 
 #[project.optional-dependencies]


### PR DESCRIPTION
- The PyChop package should be installable via pip but was not due to missing pyproject.toml or setup.py file(s).
- By providing a pyproject.toml file, setuptools can be used to install dependencies and place the PyChop module within the active python interpreter's site-packages folder.
- The setuptools pyproject.toml also allows for replacing the out-of-module PyChop.py file by an in-module __main__.py that is called by a system (or virtual environment) level script, in this case called PyChop.
- Where installation was previously a manual clone of the repository, a user should now install via pip, e.g., pip install git+{url}.
- Where launching PyChop was previously part of a Python command a user can now use the bare `PyChop` _or_ `python -m PyChop`.

## Remaining issue(s)
The specified package dependencies are not sufficient. [Installing `qtpy` does not install a working Qt backend, and one of PyQt5, PySide2, PyQt6 and PySide6 should be installed as well](https://pypi.org/project/QtPy/).
Without doing so, a user is met with a `qtpy.QtBindingsNotFoundError` on starting `PyChop`.

Can one of these backends be installed by default? What does Mantid use?